### PR TITLE
feat: 매칭 결과 페이지 디자인 개선

### DIFF
--- a/matcha-talk-vue/src/components/ChatPanel.vue
+++ b/matcha-talk-vue/src/components/ChatPanel.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="d-flex flex-column h-100">
+    <div class="flex-grow-1 overflow-y-auto pe-2" ref="messagesContainer">
+      <div
+        v-for="(msg, index) in messages"
+        :key="index"
+        class="my-1"
+      >
+        <span class="text-body-2">{{ msg }}</span>
+      </div>
+    </div>
+    <v-text-field
+      v-model="newMessage"
+      @keyup.enter="send"
+      placeholder="메시지를 입력하세요"
+      density="compact"
+      hide-details
+    >
+      <template #append-inner>
+        <v-icon @click="send" class="cursor-pointer">mdi-send</v-icon>
+      </template>
+    </v-text-field>
+  </div>
+</template>
+
+<script setup>
+import { ref, nextTick } from 'vue';
+
+const messages = ref(['안녕하세요!', '테스트 메시지']);
+const newMessage = ref('');
+const messagesContainer = ref(null);
+
+function scrollToBottom() {
+  nextTick(() => {
+    const el = messagesContainer.value;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  });
+}
+
+function send() {
+  if (newMessage.value.trim()) {
+    messages.value.push(newMessage.value.trim());
+    newMessage.value = '';
+    scrollToBottom();
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/matcha-talk-vue/src/views/MatchingResult.vue
+++ b/matcha-talk-vue/src/views/MatchingResult.vue
@@ -3,29 +3,82 @@
     <v-row justify="center">
       <v-col cols="12" md="10">
         <v-card class="pa-6">
-          <div class="text-center text-h6 text-pink-darken-2 mb-6">매칭</div>
+          <v-row class="align-center mb-6">
+            <v-avatar size="40" class="me-3">
+              <v-img :src="partnerAvatar" alt="avatar" />
+            </v-avatar>
+            <div>
+              <div class="text-h6 text-pink-darken-2">{{ partnerName }}님과 매칭되었습니다</div>
+              <div class="text-caption text-medium-emphasis">{{ sessionStatus }}</div>
+            </div>
+          </v-row>
 
           <v-row>
             <v-col cols="12" md="9">
-              <div class="rounded-lg bg-pink-lighten-5 d-flex align-center justify-center" style="height: 380px;">
-                <div class="text-subtitle-1">매칭 이미지 / 영상 영역</div>
+              <v-img
+                v-if="mediaUrl"
+                :src="mediaUrl"
+                class="rounded-lg bg-grey-lighten-2 media-wrapper"
+                cover
+              >
+                <template #placeholder>
+                  <v-row class="fill-height ma-0" align="center" justify="center">
+                    <v-progress-circular indeterminate color="pink" />
+                  </v-row>
+                </template>
+              </v-img>
+              <div
+                v-else
+                class="rounded-lg bg-pink-lighten-5 d-flex align-center justify-center media-wrapper"
+              >
+                <div class="text-subtitle-1">매칭 이미지 / 영상이 없습니다.</div>
               </div>
             </v-col>
             <v-col cols="12" md="3">
-              <v-card variant="outlined" class="pa-4" style="height: 380px;">
-                <div class="text-subtitle-2">채팅 창</div>
-                <div class="mt-2 text-caption">실시간 채팅은 WebSocket 연결 후 동작합니다.</div>
+              <v-card variant="outlined" class="pa-4 h-100 chat-wrapper d-flex flex-column">
+                <ChatPanel class="flex-grow-1" />
               </v-card>
             </v-col>
           </v-row>
 
-          <div class="text-center mt-6">
-            <v-btn color="pink" variant="tonal">매칭 수락</v-btn>
+          <div class="d-flex justify-center gap-4 mt-6">
+            <v-btn color="pink" variant="tonal" @click="acceptMatch">수락</v-btn>
+            <v-btn color="grey" variant="outlined" @click="declineMatch">거절</v-btn>
           </div>
         </v-card>
       </v-col>
     </v-row>
   </v-container>
 </template>
+
 <script setup>
+import { ref } from 'vue';
+import ChatPanel from '../components/ChatPanel.vue';
+
+const partnerName = ref('홍길동');
+const partnerAvatar = ref('https://via.placeholder.com/150');
+const sessionStatus = ref('대기 중');
+const mediaUrl = ref('https://via.placeholder.com/640x360');
+
+function acceptMatch() {
+  if (window.confirm('매칭을 수락하시겠습니까?')) {
+    // TODO: 매칭 수락 로직
+  }
+}
+
+function declineMatch() {
+  if (window.confirm('매칭을 거절하시겠습니까?')) {
+    // TODO: 매칭 거절 로직
+  }
+}
 </script>
+
+<style scoped>
+.media-wrapper {
+  max-height: 380px;
+}
+
+.chat-wrapper {
+  max-height: 380px;
+}
+</style>


### PR DESCRIPTION
## Summary
- 매칭 결과 헤더에 상대 정보와 세션 상태를 표시
- 매칭 미디어와 채팅 UI를 추가하고 액션 버튼을 개선

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b93c1587088325b1d7ceb889428566